### PR TITLE
Figured out client-side failover, improvements.

### DIFF
--- a/examples/mongodb/README.md
+++ b/examples/mongodb/README.md
@@ -1,7 +1,71 @@
 This example is desgined to be run on a mongo replicaset.
 
- * Deploy 5 mongodb units
- * Run main.go specifying the urls to use
- * It will tell you which url is the primary node
- * Use part.sh to cause a partition around the specified unit while main.go is running. Set Primary to the primary unit (ip address output from main.go)
- * See if the expected len is different from what is found in the db.
+### Deploy 5 mongodb units
+
+juju deploy mongodb -n 5
+
+### Craft a connection URL
+
+* Grab the IP address of one of the MongoDB units.
+* Get the replica set name of the cluster. Default is "myset".
+* Use <ip>:<port>?replicaSet=<replica set name> for the URL in the following steps.
+
+Example:
+
+* mongodb/2 is 10.0.3.166
+* replica set name is "jupsen"
+* URL is 10.0.3.166:27017?replicaSet=jupsen
+
+The `replicaSet` name is necessary for mgo to discover the other replica set
+members and fail over the primary during the following tests. Without it, the
+client will hang for the duration of the partition -- it won't switch to a
+newly elected primary.
+
+### Run the mongodb updates
+
+```
+go run main.go -url <URL>
+```
+
+See `go run main.go -help` for options.
+
+This will display the primary IP address. Cross-reference with `juju status` to
+find the primary unit.
+
+#### Find the current primary
+
+You can also check the current primary while the test is running, if you've
+created a partition, for example, with:
+
+```
+go run primary.go -url <URL>
+```
+
+Match the IP with `juju status` to find the primary unit.
+
+### Cause a temporary partition in the replica set
+
+`PRIMARY=<primary unit> ./part.sh`
+
+This will create a partition between two groups. The first group containing the
+given `$PRIMARY` and a secondary unit. The second group containing all the other
+secondaries. Creating this parition should force an election in which two
+primaries arise in each partition.
+
+The partition will be healed after `$DELAY` seconds. Default is 60.
+
+### See if the expected len is different from what is found in the db.
+
+So far, lost writes are easy to reproduce with a partition and `go run main.go
+-majority=false` (without write majority).
+
+With `-majority=true`, writes from a _single client_ seem to be reliable. There
+are some writes that actually happen, but are reported back as an error to the
+client. However, for an "at _least_ once" operation, this is acceptable.
+
+However, whether _multiple concurrent MongoDB client connections_ will see
+consistent results through partitions and primary failovers is yet to be
+determined.
+
+Other operations (CaS, for example) are also untested. Stay tuned.
+

--- a/examples/mongodb/README.md
+++ b/examples/mongodb/README.md
@@ -1,8 +1,20 @@
 This example is desgined to be run on a mongo replicaset.
 
-### Deploy 5 mongodb units
+### Deploy mongodb units
 
-juju deploy mongodb -n 5
+Typically you should first deploy two units:
+
+`juju deploy mongodb -n 2`
+
+Optionally set the replica set name,
+
+`juju set mongodb replicaset=mycluster`
+
+And then deploy more:
+
+`juju add-unit mongodb -n 3`
+
+See the [mongodb charm README](https://jujucharms.com/mongodb/trusty#readme) for details.
 
 ### Craft a connection URL
 

--- a/examples/mongodb/healall.sh
+++ b/examples/mongodb/healall.sh
@@ -1,15 +1,14 @@
 #!/bin/sh
 set -ev
 
-#Split brain
+N0=mongodb/0
 N1=mongodb/1
 N2=mongodb/2
 N3=mongodb/3
 N4=mongodb/4
-N5=mongodb/0
 
-for i in $N1 $N2 $N3 $N4 $N5; do
-	for j in $N1 $N2 $N3 $N4 $N5; do
+for i in $N0 $N1 $N2 $N3 $N4; do
+	for j in $N0 $N1 $N2 $N3 $N4; do
 		if [ "$i" != "$j" ]; then
 			juju jupsen heal $i $j || true
 		fi

--- a/examples/mongodb/healall.sh
+++ b/examples/mongodb/healall.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -ev
+
+#Split brain
+N1=mongodb/1
+N2=mongodb/2
+N3=mongodb/3
+N4=mongodb/4
+N5=mongodb/0
+
+for i in $N1 $N2 $N3 $N4 $N5; do
+	for j in $N1 $N2 $N3 $N4 $N5; do
+		if [ "$i" != "$j" ]; then
+			juju jupsen heal $i $j || true
+		fi
+	done
+done
+

--- a/examples/mongodb/main.go
+++ b/examples/mongodb/main.go
@@ -57,8 +57,6 @@ func WriteList(session *mgo.Session, id string, count int) Stats {
 			stats.Fail += 1
 			log.Printf("failed update: %v\n", err)
 
-			//s.Close()
-			//s = session.Copy()
 			s.Refresh()
 			continue
 		}

--- a/examples/mongodb/main.go
+++ b/examples/mongodb/main.go
@@ -11,8 +11,9 @@ import (
 )
 
 var (
-	url   = flag.String("url", "localhost:27017", "url of the mongoserver")
-	count = flag.Int("count", 6000, "number of list items")
+	url      = flag.String("url", "localhost:27017", "url of the mongoserver")
+	count    = flag.Int("count", 6000, "number of list items")
+	majority = flag.Bool("majority", true, `use WMode="majority"`)
 )
 
 type List struct {
@@ -40,18 +41,25 @@ func IsPrimary(session *mgo.Session) (string, error) {
 	return results.PrimaryAddress, nil
 }
 
-func WriteList(c *mgo.Collection, id string, count int) Stats {
+func collection(session *mgo.Session) *mgo.Collection {
+	return session.DB("jupsen").C("list")
+}
+
+func WriteList(session *mgo.Session, id string, count int) Stats {
 	stats := Stats{}
 
+	s := session.Copy()
+	defer s.Close()
 	for i := 0; i < count; i++ {
+		c := collection(s)
 		err := c.Update(bson.M{"_id": id}, bson.M{"$push": bson.M{"numbers": i}})
 		if err != nil {
 			stats.Fail += 1
 			log.Printf("failed update: %v\n", err)
-			//TODO This isn't a good way of making a new session
-			newSession := c.Database.Session.Copy()
-			c.Database.Session.Close()
-			c.Database.Session = newSession
+
+			//s.Close()
+			//s = session.Copy()
+			s.Refresh()
 			continue
 		}
 		stats.Pass += 1
@@ -63,8 +71,11 @@ func WriteList(c *mgo.Collection, id string, count int) Stats {
 	return stats
 }
 
-func Compare(c *mgo.Collection, id string, stats Stats) {
-	//TODO New session here couldn't hurt
+func Compare(session *mgo.Session, id string, stats Stats) {
+	s := session.Copy()
+	defer s.Close()
+	c := collection(s)
+
 	var result List
 	err := c.Find(bson.M{"_id": id}).One(&result)
 	if err != nil {
@@ -85,8 +96,12 @@ func main() {
 	}
 	defer session.Close()
 
-	//session.EnsureSafe(&mgo.Safe{W: 1, FSync: true})
-	session.EnsureSafe(&mgo.Safe{WMode: "majority", W: 1, FSync: true})
+	if *majority {
+		session.EnsureSafe(&mgo.Safe{WMode: "majority", W: 1, FSync: true})
+	} else {
+		session.EnsureSafe(&mgo.Safe{W: 1, FSync: true})
+	}
+
 	list := List{
 		Id:      "my-list",
 		Numbers: []int{},
@@ -98,17 +113,18 @@ func main() {
 	}
 	fmt.Printf("primary is on ip %v\n", primary)
 
-	c := session.DB("jupsen").C("list")
-	err = c.Insert(&list)
-	if err != nil {
-		log.Fatalf("failed to set starting point: %v\n", err)
-	}
-
-	stats := WriteList(c, list.Id, *count)
-	Compare(c, list.Id, stats)
+	c := collection(session)
 
 	err = c.DropCollection()
 	if err != nil {
 		log.Fatalf("failed to drop collection: %v", err)
 	}
+
+	err = c.Insert(&list)
+	if err != nil {
+		log.Fatalf("failed to set starting point: %v\n", err)
+	}
+
+	stats := WriteList(session, list.Id, *count)
+	Compare(session, list.Id, stats)
 }

--- a/examples/mongodb/part.sh
+++ b/examples/mongodb/part.sh
@@ -1,30 +1,63 @@
-#!/bin/sh
-set -ev
+#!/bin/bash -ex
 
-#Split brain
-N1=mongodb/4
+if [ -z "$DELAY" ]; then
+	DELAY=60
+fi
 
-N2=mongodb/1
-N3=mongodb/2
-N4=mongodb/3
-N5=mongodb/0
+N0=mongodb/0
+N1=mongodb/1
+N2=mongodb/2
+N3=mongodb/3
+N4=mongodb/4
 
-#Partition N1 & N2 from the others
-juju jupsen part $N1 $N2
-juju jupsen part $N1 $N3
-juju jupsen part $N1 $N4
-juju jupsen part $N1 $N5
-juju jupsen part $N2 $N1
-juju jupsen part $N2 $N3
-juju jupsen part $N2 $N4
-juju jupsen part $N2 $N5
-sleep 60
-#Heal!
-juju jupsen heal $N1 $N2
-juju jupsen heal $N1 $N3
-juju jupsen heal $N1 $N4
-juju jupsen heal $N1 $N5
-juju jupsen heal $N2 $N1
-juju jupsen heal $N2 $N3
-juju jupsen heal $N2 $N4
-juju jupsen heal $N2 $N5
+GROUP1=
+GROUP2=
+
+if [ -z "$PRIMARY" ]; then
+	echo "PRIMARY unset (use 'go run primary.go' to find it)"
+	exit 1
+fi
+
+GROUP1=
+
+for i in $N0 $N1 $N2 $N3 $N4; do
+	if [ "$PRIMARY" != "$i" ]; then
+		if [ -z "$GROUP1" ]; then
+			GROUP1="$GROUP1 $i"
+		else
+			GROUP2="$GROUP2 $i"
+		fi
+	fi
+done
+
+GROUP1="$GROUP1 $PRIMARY"
+
+echo "GROUP1=$GROUP1"
+echo "GROUP2=$GROUP2"
+
+echo "partitioning..."
+
+# Partition GROUP1 from GROUP2
+for g1 in $GROUP1; do
+	for g2 in $GROUP2; do
+		juju jupsen part $g1 $g2
+		juju jupsen part $g2 $g1
+	done
+done
+
+echo -n "partitioned"
+
+sleep $DELAY
+
+echo -n "healing..."
+
+# Heal GROUP1 & GROUP2
+for g1 in $GROUP1; do
+	for g2 in $GROUP2; do
+		juju jupsen heal $g1 $g2 || true
+		juju jupsen heal $g2 $g1 || true
+	done
+done
+
+echo "healed"
+

--- a/examples/mongodb/primary.go
+++ b/examples/mongodb/primary.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"gopkg.in/mgo.v2"
+	"log"
+)
+
+var url = flag.String("url", "localhost:27017", "url of the mongoserver")
+
+type IsPrimaryResults struct {
+	PrimaryAddress string `bson:"primary"`
+}
+
+func IsPrimary(session *mgo.Session) (string, error) {
+	results := &IsPrimaryResults{}
+	err := session.Run("isMaster", results)
+	if err != nil {
+		return "", err
+	}
+
+	return results.PrimaryAddress, nil
+}
+
+func main() {
+	flag.Parse()
+	session, err := mgo.Dial(*url)
+	if err != nil {
+		log.Fatalf("failed to connect to mongodb: %v", err)
+	}
+	defer session.Close()
+
+	primary, err := IsPrimary(session)
+	if err != nil {
+		log.Fatalf("failed to find primary: %v\n", err)
+	}
+	fmt.Printf("%v", primary)
+}


### PR DESCRIPTION
Client needs `?replicaSet` option in the URL in order to switch over to a
newly elected primary. Otherwise the client will stick to the original
primary it discovers at connect. I haven't gone through the mgo
implementation of this, but this seems to be the behavior from black-box
experimentation.

Made `part.sh` script more general -- so that its easier to isolate a
moving primary for subsequent runs.

Added `primary.go` to peek at the primary as it moves during the
partitioning. Not strictly necessary, but might be useful. For example,
if you wanted to do some nested partitioning.

Added `healall.sh` script to restore all the connections, in case the
connections get left unhealed -- if you kill part.sh part way through,
for example.

Using copied sessions -- though that probably wasn't strictly necessary;
they didn't fix the failover issue.

Updated `README`.
